### PR TITLE
Error Loading data view without context

### DIFF
--- a/src/ChartJS/widgets/Core.js
+++ b/src/ChartJS/widgets/Core.js
@@ -130,14 +130,18 @@ define([
             if (this._handle !== null) {
                 mx.data.unsubscribe(this._handle);
             }
-            this._handle = mx.data.subscribe({
-                guid: this._mxObj.getGuid(),
-                callback: lang.hitch(this, this._loadData)
-            });
-
-            // Load data again.
-            this._loadData();
-
+            if(this._mxObj) {
+                this._handle = mx.data.subscribe({
+                    guid: this._mxObj.getGuid(),
+                    callback: lang.hitch(this, this._loadData)
+                });
+    
+                // Load data again.
+                this._loadData();
+                domStyle.set(this.domNode, "display", "");
+            } else {
+                domStyle.set(this.domNode, "display", "none");
+            }
             if (typeof callback !== "undefined") {
                 callback();
             }


### PR DESCRIPTION
Check the Content of the context entity is set before rendering.
Suggested also hide the domNode if context is empty, in case some case the context entity will be empty after being rendered for the first time

Should, the display should happen before or after the _loadData function?
