### PR TITLE
Extra Padding for x labels

### DIFF
--- a/src/ChartJS/lib/charts.js
+++ b/src/ChartJS/lib/charts.js
@@ -902,7 +902,7 @@
 			ctx.font = font;
 			var longest = 0;
 			each(arrayOfStrings, function(string) {
-				var textWidth = ctx.measureText(string).width;
+				var textWidth = ctx.measureText(string).width *  1.4; //Add extra padding.
 				longest = (textWidth > longest) ? textWidth : longest;
 			});
 			return longest;


### PR DESCRIPTION
Before, we have cut off x labels:
![image](https://cloud.githubusercontent.com/assets/6724749/14636039/7bbc3c2e-0629-11e6-9464-112adb17bcc7.png)

After:
![image](https://cloud.githubusercontent.com/assets/6724749/14636025/60d46e9a-0629-11e6-94a8-6d40e89f2600.png)
